### PR TITLE
Reorganizes CSS to be based on ems for mobile-friendliness and legibility

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,41 +1,45 @@
-@import url(https://fonts.googleapis.com/css?family=Montserrat);
+/*@import url(https://fonts.googleapis.com/css?family=Montserrat);*/
 @import url(https://fonts.googleapis.com/css?family=Libre+Baskerville);
+
+html {
+  font-size: 16px;
+}
 
 body {
     text-align: center;
 }
 
 .bgimg {
-    position: fixed;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    z-index: -100;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -100;
 }
 
 h2 {
-    font-family: 'Libre Baskerville', sans-serif;
-    font-size: 50px;
-    margin-bottom: 60px;
-    margin-top: 10%;
+  font-family: 'Libre Baskerville', sans-serif;
+  font-size: 2em;
+  margin-bottom: 2.4em;
+  margin-top: 10%;
 }
-p, li{
+p, li {
     font-family: 'Libre Baskerville', serif;
-    font-size: 25px;
-    line-height: 160%;
+    font-size: 1em;
+    line-height: 2;
 }
 
 .esv-text {
-    margin-bottom: 71px;
+  margin-bottom: 2.84em;
 }
 
 .verse-num, .chapter-num {
-    font-size: 15px;
-    font-family: 'Libre Baskerville', sans-serif;
-    line-height: 160%;
-    vertical-align: text-top;
-    margin-right: 3px;
+  font-size: 0.6em;
+  font-family: 'Libre Baskerville', sans-serif;
+  line-height: 1;
+  vertical-align: text-top;
+  margin-right: 0.12em;
 }
 
 .highlight {
@@ -43,13 +47,13 @@ p, li{
 }
 
 input {
-    width: 70px;
+    width: 2.8em;
     text-align: center;
 }
 
 input, select {
-    margin-left: 5px;
-    margin-right: 5px;
+    margin-left: 0.2em;
+    margin-right: 0.2em;
 }
 
 ::-webkit-input-placeholder {
@@ -66,4 +70,16 @@ input, select {
 
 :-ms-input-placeholder {
    text-align: center;
+}
+
+@media screen and (min-width: 900px) {
+  html {
+    font-size: 20px;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  html {
+    font-size: 25px;
+  }
 }


### PR DESCRIPTION
- Added line height to paragraph text;
- Removed Montserrat from CSS import because it's not being used;
- Swapped out px-based sizing with em units in order to increase legibility across screen sizes.'

Note: I was not able to set up a local environment which means that these changes have not been tested but they are simply style changes so they should be fine.